### PR TITLE
[Lv6][feat] 일정관리 댓글과 단건 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/spartascheduler/controller/ScheduleController.java
+++ b/src/main/java/com/example/spartascheduler/controller/ScheduleController.java
@@ -2,6 +2,7 @@ package com.example.spartascheduler.controller;
 
 import com.example.spartascheduler.dto.schedule.ScheduleRequestDto;
 import com.example.spartascheduler.dto.schedule.ScheduleResponseDto;
+import com.example.spartascheduler.dto.schedule.ScheduleWithCommentsResponseDto;
 import com.example.spartascheduler.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,27 +18,38 @@ public class ScheduleController {
 
     private final ScheduleService scheduleService;
 
+    //일정 등록
     @PostMapping
     public ResponseEntity<ScheduleResponseDto> createSchedule(@RequestBody ScheduleRequestDto dto) {
         return new ResponseEntity<>(scheduleService.createSchedule(dto), HttpStatus.CREATED);
     }
 
+    //일정 전체 조회
     @GetMapping
     public ResponseEntity<List<ScheduleResponseDto>> findAllSchedules(@RequestParam(required = false) String name) {
         return new ResponseEntity<>(scheduleService.findAllSchedules(name), HttpStatus.OK);
     }
 
+    //댓글과 일정 전체 조회
+    @GetMapping("/{id}/with-comments")
+    public ResponseEntity<ScheduleWithCommentsResponseDto> findScheduleByIdWithComment(@PathVariable Long id) {
+        return new ResponseEntity<>(scheduleService.findScheduleByIdWithComment(id), HttpStatus.OK);
+    }
+
+    //일정 단건 조회
     @GetMapping("/{id}")
     public ResponseEntity<ScheduleResponseDto> findScheduleById(@PathVariable Long id) {
 
         return new ResponseEntity<>(scheduleService.findScheduleById(id), HttpStatus.OK);
     }
 
+    //일정 수정
     @PatchMapping("/{id}")
     public ResponseEntity<ScheduleResponseDto> updateSchedule(@PathVariable Long id, @RequestBody ScheduleRequestDto dto) {
         return new ResponseEntity<>(scheduleService.updateSchedule(id, dto),HttpStatus.OK);
     }
 
+    //일정 삭제
     @DeleteMapping("/{id}")
     public ResponseEntity<ScheduleResponseDto> deleteSchedule(@PathVariable Long id, @RequestBody ScheduleRequestDto dto) {
 

--- a/src/main/java/com/example/spartascheduler/dto/schedule/ScheduleWithCommentsResponseDto.java
+++ b/src/main/java/com/example/spartascheduler/dto/schedule/ScheduleWithCommentsResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.spartascheduler.dto.schedule;
+
+import com.example.spartascheduler.dto.comment.CommentResponseDto;
+import com.example.spartascheduler.entity.Schedule;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ScheduleWithCommentsResponseDto {
+
+    private String name;
+
+    private String title;
+    private String content;
+
+    private List<CommentResponseDto>  comments;
+
+    public ScheduleWithCommentsResponseDto(Schedule schedule, List<CommentResponseDto> comments) {
+        this.name = schedule.getName();
+        this.title = schedule.getTitle();
+        this.content = schedule.getContent();
+        this.comments = comments;
+    }
+
+}

--- a/src/main/java/com/example/spartascheduler/repository/CommentRepository.java
+++ b/src/main/java/com/example/spartascheduler/repository/CommentRepository.java
@@ -3,8 +3,12 @@ package com.example.spartascheduler.repository;
 import com.example.spartascheduler.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CommentRepository extends JpaRepository<Comment,Long> {
 
     long countByScheduleId(Long scheduleId);
+
+    List<Comment> findByScheduleId(Long scheduleId);
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Related to #7

## 🎯 목표
일정을 댓글과 보기

## 💻 구현 내용
- [x] 일정 단건 조회 시, 해당 일정에 등록된 댓글들을 포함하여 함께 응답
- [x]  API 응답에 `비밀번호`는 제외

## ✅ PR 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 기능 테스트 완료
- [x] 문서 및 주석 작성
- [x] 관련 이슈 번호 작성 및 연결

## 🧠 학습 포인트
댓글과 일정 함께 보기, 댓글 없이 일정만 보기 로 컨트롤러 분리를 해서 나중에 필요할 때 쓰기 좋게 만듦

## ⚠️ 문제점 및 해결 방법
작업 중 어려웠던 점과 해결 방법을 적어주세요.
