### PR TITLE
[Lv7][feat] 일정관리 유저의 입력에 대한 검증 수행 기능 구현

### DIFF
--- a/src/main/java/com/example/spartascheduler/service/CommentService.java
+++ b/src/main/java/com/example/spartascheduler/service/CommentService.java
@@ -24,6 +24,8 @@ public class CommentService {
             throw new EntityNotFoundException("해당 일정이 존재하지 않습니다.");
         }
 
+        validateComment(dto);
+
         long count = commentRepository.countByScheduleId(scheduleId);
 
         if(count > 10){
@@ -35,5 +37,17 @@ public class CommentService {
         commentRepository.save(comment);
 
         return new CommentResponseDto(comment);
+    }
+
+
+    //댓글 확인
+    private void validateComment(CommentRequestDto dto) {
+        String content = dto.getContent();
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("댓글 내용 입력은 필수값 입니다.");
+        }
+        if(content.length()>100){
+            throw new IllegalArgumentException("댓글 내용은 100자 이내로 작성해야 합니다.");
+        }
     }
 }

--- a/src/main/java/com/example/spartascheduler/service/ScheduleService.java
+++ b/src/main/java/com/example/spartascheduler/service/ScheduleService.java
@@ -29,6 +29,8 @@ public class ScheduleService {
     public ScheduleResponseDto createSchedule(ScheduleRequestDto dto) {
 
         validateNameAndPassword(dto);
+        validateTitle(dto);
+        validateContent(dto);
 
         Schedule schedule = new Schedule(dto.getName(), dto.getPassword(), dto.getTitle(), dto.getContent());
 
@@ -77,6 +79,10 @@ public class ScheduleService {
             throw new IllegalArgumentException("수정할 데이터가 없습니다.");
         }
 
+        if(dto.getTitle()!=null){
+            validateTitle(dto);
+        }
+
         Schedule schedule = getScheduleById(id);
 
         if (!schedule.getPassword().equals(dto.getPassword())) {
@@ -101,6 +107,10 @@ public class ScheduleService {
         scheduleRepository.deleteById(id);
     }
 
+
+
+
+
     //이름과 비밀번호 확인
     private void validateNameAndPassword(ScheduleRequestDto dto) {
         String name = dto.getName();
@@ -116,6 +126,29 @@ public class ScheduleService {
     private Schedule getScheduleById(Long id) {
         return scheduleRepository.findById(id).orElseThrow(() -> new EntityNotFoundException("해당 일정이 존재하지 않습니다."));
     }
+
+    //제목 확인
+    private void validateTitle(ScheduleRequestDto dto) {
+        String title = dto.getTitle();
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("제목 입력은 필수값 입니다.");
+        }
+        if(title.length()>30){
+            throw new IllegalArgumentException("제목은 30자 이내로 작성해야 합니다.");
+        }
+    }
+
+    //내용 확인
+    private void validateContent(ScheduleRequestDto dto) {
+        String content = dto.getContent();
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("일정 입력은 필수값 입니다.");
+        }
+        if(content.length()>200){
+            throw new IllegalArgumentException("일정은 200자 이내로 작성해야 합니다.");
+        }
+    }
+
 
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
Related to #7

## 🎯 목표
유저의 입력에 대한 검증 수행

## 💻 구현 내용
- [x]  `일정 제목`은 최대 30자 이내로 제한, 필수값 처리
- [x]  `일정 내용`은 최대 200자 이내로 제한, 필수값 처리
- [x]  `댓글 내용`은 최대 100자 이내로 제한, 필수값 처리
- [x]  `비밀번호`, `작성자명`은 필수값 처리
- [x]  `비밀번호`가 일치하지 않을 경우 적절한 오류 코드 및 메세지를 반환해야 합니다.

## ✅ PR 체크리스트
- [x] 커밋 메시지 컨벤션 준수
- [x] 기능 테스트 완료
- [x] 문서 및 주석 작성
- [x] 관련 이슈 번호 작성 및 연결

## 🧠 학습 포인트
" " 형태로 입력할 수도 있어서 if (content == null || content.trim().isEmpty()) { 이렇게 trim을 한 값으로도 확인을 해주어야 한다

## ⚠️ 문제점 및 해결 방법
작업 중 어려웠던 점과 해결 방법을 적어주세요.
